### PR TITLE
Corrected typo in how to start live server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Clone the repository `git clone https://github.com/Pips801/801labs-web`
 
 Install Node version 14, and run `npm ci` to get dependencies installed.
 
-Run `npm start` to spin up a local development site with hot reloading.
+Run `npm run start` to spin up a local development site with hot reloading.
 
 Once you’re done making changes or creating a new article, stop the local server process (`ctrl + c`), commit your changes (if using git), and run `npm run production`. The generated files can be found in the `/out` folder.
 


### PR DESCRIPTION
npm start does not work.  It needs to be npm run start.