### PR TITLE
Fix the 801labs.com at the bottom of the page

### DIFF
--- a/layouts/Layout.js
+++ b/layouts/Layout.js
@@ -137,7 +137,7 @@ const Layout = ({children}) => {
                         </div>
                         <div className="border-t border-white fluid-text-sm text-center pt-10 space-y-5">
                             <p>
-                                &copy; {(new Date()).getFullYear()} 801Labs.com. All rights reserved.
+                                &copy; {(new Date()).getFullYear()} 801Labs.org. All rights reserved.
                             </p>
                             <p>
                                 <Link href="/donate">

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -13,10 +13,11 @@ RewriteRule ^phishing-campaign-research-ep-2/?$  /research-portal/post/phishing-
 RewriteRule ^ascii-art-in-hidden-places/?$  /research-portal/post/ascii-art-in-hidden-places/? [R=301,NC,L]
 RewriteRule ^phishing-campaign-research/?$  /research-portal/post/phishing-campaign-research/? [R=301,NC,L]
 RewriteRule ^access-control-exploitation-part-1/?$  /research-portal/post/access-control-exploitation-part-1/? [R=301,NC,L]
-Redirect 301 /events/  https://801labs.com/get-involved/events/
-Redirect 301 /location-and-hours/  https://801labs.com/get-involved/location-and-hours/
-Redirect 301 /resources/  https://801labs.com/research-portal
-Redirect 301 /volunteer/  https://801labs.com/get-involved/
+Redirect 301 /events/  https://801labs.org/get-involved/events/
+Redirect 301 /location-and-hours/  https://801labs.org/get-involved/location-and-hours/
+Redirect 301 /resources/  https://801labs.org/research-portal
+Redirect 301 /research/  https://801labs.org/research-portal
+Redirect 301 /volunteer/  https://801labs.org/get-involved/
 
 # Redirects domain.com/file.html to domain.com/file
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
How did we go this long without noticing that the bottom of the page says 801labs.com, not .org?